### PR TITLE
Update fluidbox-wp.php

### DIFF
--- a/fluidbox-wp.php
+++ b/fluidbox-wp.php
@@ -15,9 +15,11 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 */
 
+function fluidbox_scripts(){
 wp_enqueue_style( 'jquery.fluidbox', plugins_url( 'css/fluidbox.css', __FILE__ ), false, '1.3.3' );
-
 wp_enqueue_script( 'jquery.fluidbox', plugins_url( 'js/jquery.fluidbox.min.js', __FILE__ ), array( 'jquery' ), '1.3.3', true );
 wp_enqueue_script( 'jquery.fluidboxcustom', plugins_url( 'js/fluidbox.custom.js', __FILE__ ), array( 'jquery', 'jquery.fluidbox' ), '1.0', true );
+}
+add_action( 'wp_enqueue_scripts', 'fluidbox_scripts' );
 
 ?>


### PR DESCRIPTION
Thanks for wrapping Fluidbox in a WP plugin. It is a great minimal Lightbox that I have used on several projects.

The above change enqueues the scripts correctly and prevents a warning from being displayed when WP_DEBUG is set to true in the config file.

Documentation.
http://codex.wordpress.org/Function_Reference/wp_enqueue_script